### PR TITLE
Remove `GITHUB_TOKEN` input from all workflows

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/lock.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -13,5 +13,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/pr-labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repository-updater.yaml
+++ b/.github/workflows/repository-updater.yaml
@@ -10,5 +10,4 @@ jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/repository-updater.yaml@main
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UPDATER_TOKEN: ${{ secrets.UPDATER_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/stale.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove unnecessary `GITHUB_TOKEN` input from all workflows as it breaks things.
